### PR TITLE
open keyboard when focus is on contenteditable element

### DIFF
--- a/src/chrome/content/overlay.js
+++ b/src/chrome/content/overlay.js
@@ -254,6 +254,10 @@ var fxKeyboard = {
                 // todo switch locale
             } else {
 
+                if (focus.isContentEditable) {
+                    open = true;
+                }
+
                 if (nodeName in {
                         'input': '', 'select': '',
                         'option': '', 'textarea': '', 'textbox': ''


### PR DESCRIPTION
Hi Marko
Happy new year!

Great addon, thx. We use it on a infoscreen for [openki.net](https://alpha.openki.net/kiosk/events) kiosk-view. 
To check: This patch now opens the keyboard in the description-field on [this](https://alpha.openki.net/courses/propose) page which is a richtext editor, not an input-field... 
[Our source](https://github.com/schuel/hmmm)

Hope you can release v3 soon.

lep pozdrav 
von Zürich nach Marburg